### PR TITLE
Add Streamlit web demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A small docker container shipping a small terminal application :-=
 
 ## Requirements
 
-- **Docker** (recommended)  
+- **Docker** (recommended)
   - Alternatively: **Podman** as a drop-in replacement.
 - Internet access to pull the base image `python:3.12-alpine` on first build.
 
@@ -16,3 +16,10 @@ docker build -t doktorhut-animated .
 
 # 2) Run the application in the terminal (-it allocates a TTY)
 docker run --rm -it doktorhut-animated
+```
+
+## Web Demo
+
+Try the ASCII art in your browser via Streamlit:
+
+[View the app](https://llm-congrats.streamlit.app)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,16 @@
+import os
+from pathlib import Path
+
+import streamlit as st
+
+# Determine ASCII art path relative to this file or via ART environment variable
+DEFAULT_ART = Path(__file__).with_name("ascii.txt")
+ART_PATH = Path(os.environ.get("ART", DEFAULT_ART))
+MSG = os.environ.get("MSG", "Congratulations Dr. Lennart Schürmann!")
+
+# Read ASCII art
+art = ART_PATH.read_text(encoding="utf-8")
+
+# Render using Streamlit
+st.text(art)
+st.markdown(f"**{MSG}**")


### PR DESCRIPTION
## Summary
- add Streamlit app to display ASCII art message
- document Streamlit-hosted web demo in README

## Testing
- `python -m py_compile streamlit_app.py`
- `python -m pip install streamlit` *(fails: Could not connect to proxy)*
- `python -m streamlit run streamlit_app.py --server.headless true --server.port 8501` *(fails: No module named streamlit)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9e62925083308941e01551175d2b